### PR TITLE
Global import #BetterThanNothing

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,10 @@
   "presets": [
     "es2015",
     "stage-2"
+  ],
+  "plugins": [
+    ["module-resolver", {
+      "root": ["./src"]
+    }]
   ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,12 @@
   "extends": "airbnb/base",
   "globals": {
     "it": true,
-    "describe": true
+    "describe": true,
+    "expect": true
+  },
+  "rules": {
+    "import/extensions": 0,
+    "import/no-unresolved": 0,
+    "import/no-extraneous-dependencies": 0
   }
 }

--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ import cors from 'cors';
 import path from 'path';
 import { createServer } from 'http';
 
-import api from './src/api';
-import config from './src/config';
-import connectDb from './src/db';
+import api from 'api';
+import config from 'config';
+import connectDb from 'db';
 
 const publicPath = path.join(__dirname, config.publicPath);
 const app = express();

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "main": "index.js",
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "babel-plugin-module-resolver": "^2.7.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "eslint": "^4.1.1",

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 
-import userRoutes from './user';
+import userRoutes from 'api/user';
 
 const router = Router();
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,4 +1,4 @@
-import config from './config.json';
+import config from 'config/config.json';
 
 config.port = process.env.PORT || config.port;
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,4 +1,4 @@
-import config from 'config/config.json';
+import config from './config.json';
 
 config.port = process.env.PORT || config.port;
 

--- a/src/db/db.test.js
+++ b/src/db/db.test.js
@@ -1,7 +1,7 @@
 import mongoose, { Schema } from 'mongoose';
 import { expect } from 'chai';
 
-import connectDb from './index';
+import connectDb from 'db';
 
 describe('Mongoose', () => {
   try {

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import mongoose from 'mongoose';
-import config from '../config';
+import config from 'config';
 
 export default () => {
   const { mongodb: { url, options } } = config;

--- a/src/db/init.js
+++ b/src/db/init.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import mongoose from 'mongoose';
-import connectDb from './index';
+import connectDb from 'db';
 
 (async () => {
   try {


### PR DESCRIPTION
It marks `src` as root directory and allows to import `connectDb` from `db` but not to import `user` from `api/user`.