### PR TITLE
API improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4489,6 +4489,11 @@
       "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
       "dev": true
     },
+    "dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "body-parser": "^1.17.2",
     "connect-mongo": "^1.3.2",
     "cors": "^2.8.3",
+    "dateformat": "^3.0.3",
     "express": "^4.15.3",
     "express-session": "^1.15.4",
     "lodash": "^4.17.4",

--- a/src/api/article/article.model.js
+++ b/src/api/article/article.model.js
@@ -5,48 +5,53 @@ import omit from 'lodash/omit';
 
 import { checkPermissions } from 'api/user';
 
-const ArticleSchema = new Schema({
-  author: {
-    type: Schema.Types.ObjectId,
-    ref: 'User',
-  },
-  locales: [
-    {
+const ArticleSchema = new Schema(
+  {
+    author: {
       type: Schema.Types.ObjectId,
-      ref: 'LocalizedArticle',
+      ref: 'User',
     },
-  ],
-  collectionId: {
-    type: Schema.Types.ObjectId,
-    ref: 'ArticleCollection',
+    locales: [
+      {
+        type: Schema.Types.ObjectId,
+        ref: 'LocalizedArticle',
+      },
+    ],
+    collectionId: {
+      type: Schema.Types.ObjectId,
+      ref: 'ArticleCollection',
+    },
+    brand: {
+      // May be e.g. 'wir' or 'kurilka'.
+      type: Schema.Types.ObjectId,
+      required: true,
+      ref: 'ArticleBrand',
+    },
+    type: {
+      type: String,
+      enum: ['text', 'video'],
+      required: true,
+    },
+    createdAt: {
+      type: Date,
+      default: Date.now,
+    },
+    publishAt: {
+      type: Date,
+      default: Date.now,
+    },
+    active: {
+      type: Boolean,
+      default: true,
+    },
+    imageUrl: String,
+    // This is a YouTube video ID. Ignored unless Article type is video.
+    videoId: String,
   },
-  brand: {
-    // May be e.g. 'wir' or 'kurilka'.
-    type: Schema.Types.ObjectId,
-    required: true,
-    ref: 'ArticleBrand',
-  },
-  type: {
-    type: String,
-    enum: ['text', 'video'],
-    required: true,
-  },
-  createdAt: {
-    type: Date,
-    default: Date.now,
-  },
-  publishAt: {
-    type: Date,
-    default: Date.now,
-  },
-  active: {
-    type: Boolean,
-    default: true,
-  },
-  imageUrl: String,
-  // This is a YouTube video ID. Ignored unless Article type is video.
-  videoId: String,
-});
+  {
+    usePushEach: true,
+  }
+);
 
 const Article = mongoose.model('Article', ArticleSchema);
 

--- a/src/api/article/article.model.js
+++ b/src/api/article/article.model.js
@@ -68,9 +68,10 @@ export const checkIsPublished = (article, user) => {
 };
 
 export const POPULATE_OPTIONS = {
-  author: '-_id firstName lastName email role active bio imageUrl',
-  brand: '-_id slug names',
-  collection: '-_id name slug description',
+  // TODO(uladbohdan): to merge with User basicFields.
+  author: '-_id firstName lastName email role active bio imageUrl displayName',
+  brand: '-_id slug names imageUrl imageUrlSmall',
+  collection: '-_id name slug description imageUrl',
   locales: '-_id -__v',
 };
 

--- a/src/api/article/author/tests.js
+++ b/src/api/article/author/tests.js
@@ -6,12 +6,15 @@ import 'db/connect';
 
 import { dropData } from 'utils/testing';
 
+import ArticleBrand from 'api/article/brand/model';
 import User from 'api/user/model';
 
 const request = supertest.agent(app.listen());
 
 describe('Authors API', () => {
   before(async () => {
+    await new ArticleBrand({ slug: 'wir' }).save();
+
     await Promise.all([
       User({ firstName: 'Name', email: 'author1@wir.by', role: 'author' }).save(),
       User({ firstName: 'Name', email: 'author2@wir.by', role: 'author' }).save(),
@@ -86,7 +89,7 @@ describe('Authors API', () => {
       it('should create an article with Author', () =>
         request
           .post('/api/articles')
-          .send({ type: 'video', brand: 'wir', authorEmail: 'generated-author-11@wir.by' })
+          .send({ type: 'video', brandSlug: 'wir', authorEmail: 'generated-author-11@wir.by' })
           .set('Cookie', sessionCookie)
           .expect(200)
           .expect(res => {

--- a/src/api/article/brand/model.js
+++ b/src/api/article/brand/model.js
@@ -9,10 +9,13 @@ const ArticleBrandSchema = new Schema({
     unique: true,
     validate: slugValidator,
   },
-  image: String,
   // names maps locales (be, ru, ...) to the name. Once amount of localized data for
   // ArticleBrand increases implementation of LocalizedArticleBrand model might be considered.
   names: Schema.Types.Mixed,
+  // imageUrl is a default, full-size brand logo/image.
+  imageUrl: String,
+  // imageUrlSmall is a small, resized image for i.e. article tiles preview.
+  imageUrlSmall: String,
 });
 
 export const ArticleBrand = mongoose.model('ArticleBrand', ArticleBrandSchema);

--- a/src/api/article/collection/controller.js
+++ b/src/api/article/collection/controller.js
@@ -15,7 +15,7 @@ export const getOne = ({ params: { slug } }, res, next) =>
     .then(sendJson(res))
     .catch(next);
 
-export const create = async ({ body }, res, next) =>
+export const create = ({ body }, res, next) =>
   ArticleCollection(body)
     .save()
     .then(sendJson(res))

--- a/src/api/article/collection/model.js
+++ b/src/api/article/collection/model.js
@@ -28,6 +28,7 @@ const ArticleCollectionSchema = new Schema({
     type: Boolean,
     default: true,
   },
+  imageUrl: String,
 });
 
 export const ArticleCollection = mongoose.model('ArticleCollection', ArticleCollectionSchema);

--- a/src/api/article/controller.tests.js
+++ b/src/api/article/controller.tests.js
@@ -201,17 +201,51 @@ describe('Articles API', () => {
           expect(res.body.title).equal('title-new');
         }));
 
+    let articleId;
+
     it('should update an article', () =>
       request
         .put('/api/articles/article-new')
         .send({
-          // TODO(uladbohdan): to replace with a better example of an update.
-          active: true,
+          imageUrl: 'new-image-url',
         })
         .set('Cookie', sessionCookie)
         .expect(200)
         .expect(res => {
+          articleId = res.body._id;
+          expect(res.body.imageUrl).equal('new-image-url');
           expect(res.body.active).equal(true);
+        }));
+
+    it('should get an article by ID', () =>
+      request
+        .get(`/api/articles/${articleId}`)
+        .expect(200)
+        .expect(res => {
+          expect(res.body.imageUrl).equal('new-image-url');
+        }));
+
+    it('should fail to get an article due to invalid ID', () =>
+      request.get(`/api/articles/${articleId}X`).expect(404));
+
+    it('should remove an article by ID', () =>
+      request
+        .delete(`/api/articles/${articleId}`)
+        .set('Cookie', sessionCookie)
+        .expect(200));
+
+    it('should fail to get removed article by ID', () =>
+      request.get(`/api/articles/${articleId}X`).expect(404));
+
+    it('should recover an article by ID', () =>
+      request
+        .put(`/api/articles/${articleId}`)
+        .send({ active: true })
+        .set('Cookie', sessionCookie)
+        .expect(200)
+        .expect(res => {
+          expect(res.body.imageUrl).to.equal('new-image-url');
+          expect(res.body.active).to.equal(true);
         }));
 
     it('should remove an article', () =>

--- a/src/api/article/controller.tests.js
+++ b/src/api/article/controller.tests.js
@@ -520,6 +520,13 @@ describe('Articles Bundled API', () => {
       .send({ type: '' })
       .expect(400));
 
+  it('should fail to remove article type', () =>
+    request
+      .put('/api/articles/new-en-slug')
+      .set('Cookie', sessionCookie)
+      .send({ type: '' })
+      .expect(400));
+
   it('should fail to remove localization title', () =>
     request
       .put('/api/articles/new-en-slug')

--- a/src/api/article/controller.tests.js
+++ b/src/api/article/controller.tests.js
@@ -208,13 +208,15 @@ describe('Articles API', () => {
         .put('/api/articles/article-new')
         .send({
           imageUrl: 'new-image-url',
+          locales: { en: {} }, // This is for server to keep the locale.
         })
         .set('Cookie', sessionCookie)
         .expect(200)
         .expect(res => {
           articleId = res.body._id;
-          expect(res.body.imageUrl).equal('new-image-url');
-          expect(res.body.active).equal(true);
+          expect(res.body.imageUrl).to.equal('new-image-url');
+          expect(res.body.active).to.equal(true);
+          expect(res.body.locales.en.title).to.equal('title-new');
         }));
 
     it('should get an article by ID', () =>
@@ -223,6 +225,7 @@ describe('Articles API', () => {
         .expect(200)
         .expect(res => {
           expect(res.body.imageUrl).equal('new-image-url');
+          expect(res.body.locales.en.slug).to.equal('article-new');
         }));
 
     it('should fail to get an article due to invalid ID', () =>
@@ -235,17 +238,25 @@ describe('Articles API', () => {
         .expect(200));
 
     it('should fail to get removed article by ID', () =>
-      request.get(`/api/articles/${articleId}X`).expect(404));
+      request.get(`/api/articles/${articleId}`).expect(404));
 
     it('should recover an article by ID', () =>
       request
         .put(`/api/articles/${articleId}`)
-        .send({ active: true })
+        .send({ active: true, locales: { en: {} } })
         .set('Cookie', sessionCookie)
         .expect(200)
         .expect(res => {
           expect(res.body.imageUrl).to.equal('new-image-url');
           expect(res.body.active).to.equal(true);
+        }));
+
+    it('should get an article by slug', () =>
+      request
+        .get(`/api/articles/article-new`)
+        .expect(200)
+        .expect(res => {
+          expect(res.body.locales.en.slug).to.equal('article-new');
         }));
 
     it('should remove an article', () =>
@@ -466,7 +477,7 @@ describe('Articles Bundled API', () => {
         expect(res.body.locales.en.subtitle).to.equal('en-subtitle');
       }));
 
-  it('should not found an article with removed localization', () =>
+  it('should not find an article with removed localization', () =>
     request.get('/api/articles/be-slug').expect(404));
 
   it('should add two new locales and update existent one', () =>

--- a/src/api/article/index.js
+++ b/src/api/article/index.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 
 import { requireAuth, verifyPermission } from 'auth';
+import { requireFields, precheck } from 'utils/validation';
 
 import authorRoutes from 'api/article/author';
 import brandRoutes from 'api/article/brand';
@@ -23,10 +24,23 @@ router.use('/collections', collectionRoutes);
 router.use('/localize', localeRoutes);
 
 router.get('/', controller.getAll);
-router.post('/', requireAuth, verifyPermission('canCreateArticle'), controller.create);
+router.post(
+  '/',
+  requireAuth,
+  verifyPermission('canCreateArticle'),
+  requireFields('brandSlug', 'type'),
+  precheck.createArticle,
+  controller.create
+);
 // slugOrId parameter below either contains ID of an Article or a slug of any Article Localization.
 router.get('/:slugOrId', controller.getOne);
-router.put('/:slugOrId', requireAuth, verifyPermission('canCreateArticle'), controller.update);
+router.put(
+  '/:slugOrId',
+  requireAuth,
+  verifyPermission('canCreateArticle'),
+  precheck.updateArticle,
+  controller.update
+);
 router.delete('/:slugOrId', requireAuth, verifyPermission('canCreateArticle'), controller.remove);
 
 export { Article, ArticleBrand, ArticleCollection, LocalizedArticle };

--- a/src/api/article/index.js
+++ b/src/api/article/index.js
@@ -24,10 +24,10 @@ router.use('/localize', localeRoutes);
 
 router.get('/', controller.getAll);
 router.post('/', requireAuth, verifyPermission('canCreateArticle'), controller.create);
-// slug parameter below is any of Article slugs (any localization).
-router.get('/:slug', controller.getOne);
-router.put('/:slug', requireAuth, verifyPermission('canCreateArticle'), controller.update);
-router.delete('/:slug', requireAuth, verifyPermission('canCreateArticle'), controller.remove);
+// slugOrId parameter below either contains ID of an Article or a slug of any Article Localization.
+router.get('/:slugOrId', controller.getOne);
+router.put('/:slugOrId', requireAuth, verifyPermission('canCreateArticle'), controller.update);
+router.delete('/:slugOrId', requireAuth, verifyPermission('canCreateArticle'), controller.remove);
 
 export { Article, ArticleBrand, ArticleCollection, LocalizedArticle };
 export default router;

--- a/src/api/article/localized/controller.js
+++ b/src/api/article/localized/controller.js
@@ -6,6 +6,7 @@ import Article from 'api/article/article.model';
 
 import LocalizedArticle from './model';
 
+// TODO(uladbohdan): to refactor using then-chaining.
 export const create = async ({ params: { articleId }, body }, res, next) => {
   try {
     const article = await Article.findOne({ _id: articleId }).populate('locales', 'locale');

--- a/src/api/article/localized/controller.js
+++ b/src/api/article/localized/controller.js
@@ -6,7 +6,6 @@ import Article from 'api/article/article.model';
 
 import LocalizedArticle from './model';
 
-// TODO(uladbohdan): to refactor using then-chaining.
 export const create = async ({ params: { articleId }, body }, res, next) => {
   try {
     const article = await Article.findOne({ _id: articleId }).populate('locales', 'locale');

--- a/src/api/article/localized/model.js
+++ b/src/api/article/localized/model.js
@@ -32,6 +32,10 @@ const LocalizedArticleSchema = new Schema({
     type: Date,
     default: Date.now,
   },
+  active: {
+    type: Boolean,
+    default: true,
+  },
 });
 
 const LocalizedArticle = mongoose.model('LocalizedArticle', LocalizedArticleSchema);

--- a/src/api/specials/diary/controller.js
+++ b/src/api/specials/diary/controller.js
@@ -1,4 +1,4 @@
-import { checkIsFound } from 'utils/validation';
+import { checkDiaryIsFound } from 'utils/validation';
 import { sendJson } from 'utils/api';
 
 import Diary from './model';
@@ -6,7 +6,7 @@ import Diary from './model';
 export const getDay = ({ params: { locale, month, day } }, res, next) =>
   Diary.findOne({ locale, colloquialDate: `${month}-${day}`, active: true })
     .select('-_id -__v')
-    .then(checkIsFound)
+    .then(checkDiaryIsFound)
     .then(sendJson(res))
     .catch(next);
 

--- a/src/api/specials/diary/controller.js
+++ b/src/api/specials/diary/controller.js
@@ -1,5 +1,6 @@
 import { checkDiaryIsFound } from 'utils/validation';
 import { sendJson } from 'utils/api';
+import dateFormat from 'dateformat';
 
 import Diary from './model';
 
@@ -7,6 +8,29 @@ export const getDay = ({ params: { locale, month, day } }, res, next) =>
   Diary.findOne({ locale, colloquialDate: `${month}-${day}`, active: true })
     .select('-_id -__v')
     .then(checkDiaryIsFound)
+    .then(async diary => {
+      const date = new Date(`2018-${month}-${day}`);
+      const prevDate = new Date(date);
+      prevDate.setDate(date.getDate() - 1);
+      const nextDate = new Date(date);
+      nextDate.setDate(date.getDate() + 1);
+
+      const [prevExists, nextExists] = await Promise.all(
+        [prevDate, nextDate].map(curDate =>
+          Diary.findOne({
+            locale,
+            colloquialDate: dateFormat(curDate, 'mm-dd'),
+            active: true,
+          }).then(d => Boolean(d))
+        )
+      );
+
+      return {
+        data: diary,
+        prev: prevExists,
+        next: nextExists,
+      };
+    })
     .then(sendJson(res))
     .catch(next);
 

--- a/src/api/specials/diary/controller.js
+++ b/src/api/specials/diary/controller.js
@@ -41,11 +41,11 @@ export const getDay = async ({ params: { locale, month, day } }, res, next) => {
 
     return sendJson(res)({
       data: serializeDiary(diary),
-      prev: Boolean(bestPrev) && {
+      prev: !!bestPrev && {
         month: bestPrev.month,
         day: bestPrev.day,
       },
-      next: Boolean(bestNext) && {
+      next: !!bestNext && {
         month: bestNext.month,
         day: bestNext.day,
       },

--- a/src/api/specials/diary/controller.js
+++ b/src/api/specials/diary/controller.js
@@ -1,4 +1,4 @@
-import { checkDiaryIsFound } from 'utils/validation';
+import { checkIsFound } from 'utils/validation';
 import { sendJson } from 'utils/api';
 import dateFormat from 'dateformat';
 
@@ -7,7 +7,7 @@ import Diary from './model';
 export const getDay = ({ params: { locale, month, day } }, res, next) =>
   Diary.findOne({ locale, colloquialDate: `${month}-${day}`, active: true })
     .select('-_id -__v')
-    .then(checkDiaryIsFound)
+    .then(d => checkIsFound(d, 204))
     .then(async diary => {
       const date = new Date(`2018-${month}-${day}`);
       const prevDate = new Date(date);
@@ -21,7 +21,7 @@ export const getDay = ({ params: { locale, month, day } }, res, next) =>
             locale,
             colloquialDate: dateFormat(curDate, 'mm-dd'),
             active: true,
-          }).then(d => Boolean(d))
+          }).then(Boolean)
         )
       );
 

--- a/src/api/specials/diary/model.js
+++ b/src/api/specials/diary/model.js
@@ -1,6 +1,7 @@
 import mongoose, { Schema } from 'mongoose';
+import pick from 'lodash/pick';
 
-import { colloquialDateValidator } from 'utils/validation';
+import { colloquialDateHashValidator } from 'utils/validation';
 
 const DiarySchema = new Schema({
   locale: {
@@ -15,10 +16,12 @@ const DiarySchema = new Schema({
     type: String,
     required: true,
   },
-  colloquialDate: {
-    type: String,
+  colloquialDateHash: {
+    // ColloquialDateHash is a hash of date, equals to (month * 100 + day).
+    // This is for diaries to be easily sorted with mongoose tools.
+    type: Number,
     required: true,
-    validate: colloquialDateValidator,
+    validate: colloquialDateHashValidator,
   },
   year: String,
   createdAt: {
@@ -30,6 +33,24 @@ const DiarySchema = new Schema({
     default: true,
   },
 });
+
+DiarySchema.virtual('month').get(function get() {
+  return Math.floor(parseInt(this.colloquialDateHash, 10) / 100)
+    .toString(10)
+    .padStart(2, '0');
+});
+
+DiarySchema.virtual('day').get(function get() {
+  return Math.floor(parseInt(this.colloquialDateHash, 10) % 100)
+    .toString(10)
+    .padStart(2, '0');
+});
+
+export const buildColloquialDateHash = (month, day) =>
+  parseInt(month, 10) * 100 + parseInt(day, 10);
+
+export const serializeDiary = object =>
+  pick(object, ['locale', 'text', 'author', 'year', 'month', 'day']);
 
 export const Diary = mongoose.model('Diary', DiarySchema);
 

--- a/src/api/specials/diary/tests.js
+++ b/src/api/specials/diary/tests.js
@@ -33,6 +33,6 @@ describe('Diary API', () => {
           expect(res.body.year).to.equal('2018');
         }));
 
-    it('request unexisting diary', () => request.get('/api/specials/diary/be/02/15').expect(404));
+    it('request unexisting diary', () => request.get('/api/specials/diary/be/02/15').expect(204));
   });
 });

--- a/src/api/specials/diary/tests.js
+++ b/src/api/specials/diary/tests.js
@@ -12,25 +12,62 @@ const request = supertest.agent(app.listen());
 
 describe('Diary API', () => {
   before(async () => {
-    await Diary({
-      author: 'TestAuthor',
-      text: 'SomeDiary',
-      colloquialDate: '02-14',
-      locale: 'be',
-      year: '2018',
-    }).save();
+    await Promise.all([
+      Diary({
+        author: 'Author1',
+        text: 'Diary02-27',
+        colloquialDate: '02-27',
+        locale: 'be',
+      }).save(),
+      Diary({
+        author: 'Author2',
+        text: 'Diary02-28',
+        colloquialDate: '02-28',
+        locale: 'be',
+        year: '2018',
+      }).save(),
+      Diary({
+        author: 'Author3',
+        text: 'Diary03-01',
+        colloquialDate: '03-01',
+        locale: 'be',
+      }).save(),
+    ]);
   });
 
   after(dropData);
 
   describe('# Diary CRUD', () => {
-    it('get an existing diary', () =>
+    it('get an existing diary with prev and next', () =>
       request
-        .get('/api/specials/diary/be/02/14/')
+        .get('/api/specials/diary/be/02/28/')
         .expect(200)
-        .expect(res => {
-          expect(res.body.author).to.equal('TestAuthor');
-          expect(res.body.year).to.equal('2018');
+        .expect(({ body: { data, prev, next } }) => {
+          expect(data.author).to.equal('Author2');
+          expect(data.year).to.equal('2018');
+          expect(data.colloquialDate).to.equal('02-28');
+          expect(prev).to.equal(true);
+          expect(next).to.equal(true);
+        }));
+
+    it('get a diary with next only', () =>
+      request
+        .get('/api/specials/diary/be/02/27')
+        .expect(200)
+        .expect(({ body: { data, prev, next } }) => {
+          expect(data.author).to.equal('Author1');
+          expect(prev).to.equal(false);
+          expect(next).to.equal(true);
+        }));
+
+    it('get a diary with prev only', () =>
+      request
+        .get('/api/specials/diary/be/03/01')
+        .expect(200)
+        .expect(({ body: { data, prev, next } }) => {
+          expect(data.author).to.equal('Author3');
+          expect(prev).to.equal(true);
+          expect(next).to.equal(false);
         }));
 
     it('request unexisting diary', () => request.get('/api/specials/diary/be/02/15').expect(204));

--- a/src/api/user/model.js
+++ b/src/api/user/model.js
@@ -9,6 +9,8 @@ const UserSchema = new Schema({
   // to the values. A set of locales must be the same for all of the fields mentioned.
   // For a User with a role 'regular' firstName, lastName and bio are Strings;
   // the language of these strings is undefined.
+  // TODO(uladbohdan): to implement validator to verify the set of locales is the same
+  // for all the fields.
   firstName: {
     type: Schema.Types.Mixed,
     required: true,

--- a/src/api/user/model.js
+++ b/src/api/user/model.js
@@ -32,8 +32,9 @@ const UserSchema = new Schema({
   imageUrl: String,
 });
 
-UserSchema.virtual('name').get(function get() {
-  return `${this.firstName} ${this.lastName}`;
+UserSchema.virtual('displayName').get(function get() {
+  const postfix = this.lastName ? ` ${this.lastName}` : '';
+  return `${this.firstName}${postfix}`;
 });
 
 UserSchema.virtual('password').get(function get() {
@@ -55,7 +56,16 @@ UserSchema.methods.authenticate = async function authenticate(password) {
 
 const User = mongoose.model('User', UserSchema);
 
-const basicFields = ['firstName', 'lastName', 'email', 'role', 'active', 'bio', 'imageUrl'];
+const basicFields = [
+  'firstName',
+  'lastName',
+  'displayName',
+  'email',
+  'role',
+  'active',
+  'bio',
+  'imageUrl',
+];
 
 export const serializeUser = object => pick(object, [...basicFields, 'permissions']);
 

--- a/src/api/user/model.js
+++ b/src/api/user/model.js
@@ -5,6 +5,10 @@ import pick from 'lodash/pick';
 import config from 'config';
 
 const UserSchema = new Schema({
+  // For a User with a role 'author' firstName, lastName and bio map locales
+  // to the values. A set of locales must be the same for all of the fields mentioned.
+  // For a User with a role 'regular' firstName, lastName and bio are Strings;
+  // the language of these strings is undefined.
   firstName: {
     type: Schema.Types.Mixed,
     required: true,
@@ -33,8 +37,19 @@ const UserSchema = new Schema({
 });
 
 UserSchema.virtual('displayName').get(function get() {
-  const postfix = this.lastName ? ` ${this.lastName}` : '';
-  return `${this.firstName}${postfix}`;
+  const joinNames = (firstName, lastName) => {
+    const postfix = lastName ? ` ${lastName}` : '';
+    return `${firstName}${postfix}`;
+  };
+  if (this.role === 'author') {
+    const result = {};
+    Object.keys(this.firstName).forEach(locale => {
+      result[locale] = joinNames(this.firstName[locale], this.lastName && this.lastName[locale]);
+    });
+    return result;
+  }
+  // The role is 'regular' (default).
+  return joinNames(this.firstName, this.lastName);
 });
 
 UserSchema.virtual('password').get(function get() {

--- a/src/api/user/model.js
+++ b/src/api/user/model.js
@@ -1,8 +1,10 @@
 import mongoose, { Schema } from 'mongoose';
 import { genSalt, hash, compare } from 'bcrypt';
+import fromPairs from 'lodash/fromPairs';
 import pick from 'lodash/pick';
 
 import config from 'config';
+import { joinNames } from 'utils/formatting';
 
 const UserSchema = new Schema({
   // For a User with a role 'author' firstName, lastName and bio map locales
@@ -39,16 +41,13 @@ const UserSchema = new Schema({
 });
 
 UserSchema.virtual('displayName').get(function get() {
-  const joinNames = (firstName, lastName) => {
-    const postfix = lastName ? ` ${lastName}` : '';
-    return `${firstName}${postfix}`;
-  };
   if (this.role === 'author') {
-    const result = {};
-    Object.keys(this.firstName).forEach(locale => {
-      result[locale] = joinNames(this.firstName[locale], this.lastName && this.lastName[locale]);
-    });
-    return result;
+    return fromPairs(
+      Object.entries(this.firstName).map(([l, firstName]) => [
+        l,
+        joinNames(firstName, this.lastName && this.lastName[l]),
+      ])
+    );
   }
   // The role is 'regular' (default).
   return joinNames(this.firstName, this.lastName);

--- a/src/api/user/tests.js
+++ b/src/api/user/tests.js
@@ -27,7 +27,7 @@ describe('User model', () => {
 
   it('should only return firstName as displayName', async () => {
     const result = await User.findOne({ email });
-    expect(result.displayName).to.equal(`${firstName}`);
+    expect(result.displayName).to.equal(firstName);
   });
 
   it('should return firstName and lastName as displayName', async () => {
@@ -48,5 +48,38 @@ describe('User model', () => {
     await User.remove({ email });
     const result = await User.findOne({ email });
     expect(result).to.be.null; // eslint-disable-line no-unused-expressions
+  });
+});
+
+describe('User model as Author', () => {
+  const authorData = {
+    firstName: { be: 'FirstName-be', en: 'FirstName-en' },
+    email: 'generated-author@wir.by',
+    role: 'author',
+  };
+
+  const { firstName, email } = authorData;
+  const author = new User(authorData);
+
+  after(dropData);
+
+  it('should save author', async () => {
+    const result = await author.save();
+    expect(result.email).to.equal(email);
+  });
+
+  it('should return proper displayName', async () => {
+    const result = await User.findOne({ email });
+    expect(Object.keys(result.displayName)).has.length(Object.keys(firstName).length);
+    expect(result.displayName.be).to.equal(firstName.be);
+    expect(result.displayName.en).to.equal(firstName.en);
+  });
+
+  it('displayName should join with lastName', async () => {
+    const lastName = { be: 'LastName-be', en: 'LastName-en' };
+    const result = await User.findOneAndUpdate({ email }, { lastName }, { new: true }).exec();
+    expect(Object.keys(result.displayName)).has.length(Object.keys(firstName).length);
+    expect(result.displayName.be).to.equal(`${firstName.be} ${lastName.be}`);
+    expect(result.displayName.en).to.equal(`${firstName.en} ${lastName.en}`);
   });
 });

--- a/src/api/user/tests.js
+++ b/src/api/user/tests.js
@@ -7,7 +7,7 @@ import User from './model';
 
 describe('User model', () => {
   const userData = { firstName: 'Name', email: 'test@test.test', password: 'secret' };
-  const { email, password } = userData;
+  const { firstName, email, password } = userData;
   const user = new User(userData);
 
   after(dropData);
@@ -23,6 +23,17 @@ describe('User model', () => {
     const result = await User.findOne({ email });
     expect(result.email).to.equal(email);
     expect(result.password).to.equal(user.password);
+  });
+
+  it('should only return firstName as displayName', async () => {
+    const result = await User.findOne({ email });
+    expect(result.displayName).to.equal(`${firstName}`);
+  });
+
+  it('should return firstName and lastName as displayName', async () => {
+    const lastName = 'LastName';
+    const result = await User.findOneAndUpdate({ email }, { lastName }, { new: true }).exec();
+    expect(result.displayName).to.equal(`${firstName} ${lastName}`);
   });
 
   it('should crypt password', () => expect(user.password).to.not.equal(password));

--- a/src/db/articleBrands.json
+++ b/src/db/articleBrands.json
@@ -5,21 +5,26 @@
       "be": "Wir.by - Адукацыйная платформа",
       "ru": "Wir.by - Образовательная платформа",
       "en": "Wir.by - Educational platform"
-    }
+    },
+    "imageUrl": "http://res.cloudinary.com/dhgy4yket/image/upload/v1522527204/babajka-dev/wir-logo.jpg",
+    "imageUrlSmall": "http://res.cloudinary.com/dhgy4yket/image/upload/c_scale,w_100/v1522527204/babajka-dev/wir-logo.jpg"
   },
   {
     "slug": "kurilka",
-    "image": "kurilka-logo.png",
     "names": {
       "be": "Курылка Гутэнберга",
       "ru": "Курилка Гутенберга"
-    }
+    },
+    "imageUrl": "http://res.cloudinary.com/dhgy4yket/image/upload/v1522527334/babajka-dev/kurilka.jpg",
+    "imageUrlSmall": "http://res.cloudinary.com/dhgy4yket/image/upload/c_scale,w_100/v1522527334/babajka-dev/kurilka.jpg"
   },
   {
     "slug": "15x4",
     "names": {
       "be": "Мінск",
       "ru": "Минск"
-    }
+    },
+    "imageUrl": "http://res.cloudinary.com/dhgy4yket/image/upload/v1522527434/babajka-dev/15x4.png",
+    "imageUrlSmall": "http://res.cloudinary.com/dhgy4yket/image/upload/c_scale,w_100/v1522527434/babajka-dev/15x4.png"
   }
 ]

--- a/src/db/articleCollections.json
+++ b/src/db/articleCollections.json
@@ -11,6 +11,7 @@
       "en": "The description of the very first collection"
     },
     "slug": "collection0",
-    "articleSlugs": ["slug0", "slug1"]
+    "articleSlugs": ["slug0", "slug1"],
+    "imageUrl": "/images/collection-folder-image.jpg"
   }
 ]

--- a/src/db/diary.json
+++ b/src/db/diary.json
@@ -2,22 +2,22 @@
   {
     "author": "Author1",
     "text": "Diary text 1",
-    "locale": "be",
-    "colloquialDate": "02-13",
+    "locale": "en",
+    "colloquialDateHash": "0213",
     "year": "2018"
   },
   {
     "author": "Author2",
     "text": "Diary text 2",
     "locale": "en",
-    "colloquialDate": "02-14",
+    "colloquialDateHash": "0214",
     "year": "2001"
   },
   {
     "author": "Author3",
     "text": "Diary text 3",
-    "locale": "ru",
-    "colloquialDate": "02-15",
+    "locale": "en",
+    "colloquialDateHash": "0215",
     "year": "1985"
   }
 ]

--- a/src/db/users.json
+++ b/src/db/users.json
@@ -1,43 +1,24 @@
 [
   {
     "email": "admin@babajka.io",
-    "firstName": {
-      "en": "Fox",
-      "be": "Фокс"
-    },
-    "lastName": {
-      "en": "Muller",
-      "be": "Мюллер"
-    },
+    "firstName": "Fox",
+    "lastName": "Muller",
     "password": "password",
     "permissionsPreset": "admin"
   },
   {
     "email": "creator@babajka.io",
-    "firstName": {
-      "en": "Dana"
-    },
-    "lastName": {
-      "en": "Scally"
-    },
+    "firstName": "Dana",
+    "lastName": "Scally",
     "password": "password1",
     "permissionsPreset": "contentManager"
   },
   {
     "email": "user@babajka.io",
-    "firstName": {
-      "en": "John",
-      "be": "Джон"
-    },
-    "lastName": {
-      "en": "Smith",
-      "be": "Сміт"
-    },
+    "firstName": "Джон",
+    "lastName": "Сміт",
     "password": "password2",
-    "bio": {
-      "en": "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-      "be": "бла-бла-бла"
-    },
+    "bio": "бла-бла-бла",
     "imageUrl": "/test/images/einstein.jpeg"
   },
   {

--- a/src/utils/formatting.js
+++ b/src/utils/formatting.js
@@ -1,1 +1,6 @@
 export const cutUrlParams = url => url && url.split('?', 1)[0];
+
+export const joinNames = (firstName, lastName) => {
+  const postfix = lastName ? ` ${lastName}` : '';
+  return `${firstName}${postfix}`;
+};

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -81,8 +81,12 @@ export const slugValidator = {
   message: 'failed to match regexp',
 };
 
-export const colloquialDateValidator = {
-  // Colloquial Date has MM-DD format.
-  validator: v => /\d{2}-\d{2}/.test(v),
+export const colloquialDateHashValidator = {
+  // Colloquial Date Hash has MMDD format.
+  validator: v => {
+    const month = parseInt(v, 10) / 100;
+    const day = parseInt(v, 10) % 100;
+    return month >= 0 && month <= 12 && day >= 0 && day <= 31;
+  },
   message: 'failed to match regexp',
 };

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -23,7 +23,13 @@ export const checkIsFound = object => {
   if (!object) {
     throw new HttpError(404);
   }
+  return object;
+};
 
+export const checkDiaryIsFound = object => {
+  if (!object) {
+    throw new HttpError(204);
+  }
   return object;
 };
 

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -4,6 +4,61 @@ import mongoose from 'mongoose';
 
 export const ValidationError = message => HttpError(400, message);
 
+// TODO(uladbohdan): to replace messages with error codes.
+
+// These are the drafts for validators.
+// TODO(uladbohdan): to refactor, to extend.
+
+// TODO(uladbohdan): to figure out nesting in errors object.
+
+const createArticleValidator = ({ body }, res, next) => {
+  const errors = {};
+  if (body.locales) {
+    Object.keys(body.locales).forEach(loc => {
+      ['title', 'subtitle', 'slug', 'text', 'locale'].forEach(field => {
+        if (!body.locales[loc][field]) {
+          errors[field] = 'must be presented';
+        }
+      });
+      if (loc !== body.locales[loc].locale) {
+        errors.localeConsistency = `bad locale structuring: ${loc} vs. ${body.locales[loc].locale}`;
+      }
+    });
+  }
+  if (!isEmpty(errors)) {
+    return next(new ValidationError(errors));
+  }
+  return next();
+};
+
+const updateArticleValidator = ({ body }, res, next) => {
+  const errors = {};
+
+  ['brandSlug', 'type'].forEach(field => {
+    if (body[field] === '') {
+      errors[field] = 'you cannot remove the field';
+    }
+  });
+  if (body.locales) {
+    Object.keys(body.locales).forEach(loc => {
+      ['title', 'subtitle', 'slug', 'text', 'locale'].forEach(field => {
+        if (body.locales[loc][field] === '') {
+          errors[field] = 'you cannot remove the field';
+        }
+      });
+    });
+  }
+  if (!isEmpty(errors)) {
+    return next(new ValidationError(errors));
+  }
+  return next();
+};
+
+export const precheck = {
+  createArticle: createArticleValidator,
+  updateArticle: updateArticleValidator,
+};
+
 export const requireFields = (...fields) => (req, res, next) => {
   const errors = {};
 

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -7,9 +7,6 @@ export const ValidationError = message => HttpError(400, message);
 
 // TODO(uladbohdan): to replace messages with error codes.
 
-// These are the drafts for validators.
-// TODO(uladbohdan): to refactor, to extend.
-
 const createArticleValidator = ({ body }, res, next) => {
   const errors = {};
   if (body.locales) {
@@ -20,7 +17,7 @@ const createArticleValidator = ({ body }, res, next) => {
         }
       });
       if (locale !== localeData.locale) {
-        errors.localeConsistency = `bad locale structuring: ${locale} vs. ${localeData.locale}`;
+        errors.localeConsistency = `bad locale consistency: ${locale} vs. ${localeData.locale}`;
       }
     });
   }
@@ -33,7 +30,7 @@ const updateArticleValidator = ({ body }, res, next) => {
 
   ['brandSlug', 'type'].forEach(field => {
     if (body[field] === '') {
-      errors[field] = 'you cannot remove the field';
+      errors[field] = 'forbidden to remove';
     }
   });
 
@@ -41,9 +38,12 @@ const updateArticleValidator = ({ body }, res, next) => {
     Object.entries(body.locales).forEach(([locale, localeData]) => {
       ['title', 'subtitle', 'slug', 'text', 'locale'].forEach(field => {
         if (localeData[field] === '') {
-          set(errors, ['locales', locale, field], 'cannot be removed');
+          set(errors, ['locales', locale, field], 'forbidden to remove');
         }
       });
+      if (localeData.locale && localeData.locale !== locale) {
+        errors.localeConsistency = `bad locale consistency: ${locale} vs. ${localeData.locale}`;
+      }
     });
   }
 

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,5 +1,6 @@
 import HttpError from 'node-http-error';
 import isEmpty from 'lodash/isEmpty';
+import mongoose from 'mongoose';
 
 export const ValidationError = message => HttpError(400, message);
 
@@ -25,6 +26,8 @@ export const checkIsFound = object => {
 
   return object;
 };
+
+export const isValidId = id => mongoose.Types.ObjectId.isValid(id);
 
 export const slugValidator = {
   validator: v => /^[a-zA-Z0-9_-]+$/.test(v),

--- a/src/utils/validation.tests.js
+++ b/src/utils/validation.tests.js
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+
+import { slugValidator } from './validation';
+
+describe('Slug Validation Tests', () => {
+  const validate = slugValidator.validator;
+
+  it('should not accept empty strings', () => expect(validate('')).to.be.false);
+
+  it('should not accept some special characters', () =>
+    expect(validate('hello$world?f')).to.be.false);
+
+  it('should accept alphnumeric', () => expect(validate('regular-slug_01')).to.be.true);
+
+  it('should not accept cyrillic slug', () => expect(validate('прывітанне-слаг-05')).to.be.false);
+});


### PR DESCRIPTION
* `imageUrl` is added to `ArticleBrand` and `ArticleCollection`. In addition, `ArticleBrand` has `imageUrlSmall` field.
* `firstName`, `lastName` and `bio` are Strings for regular users and locale maps for author users.
* `displayName` is returned for every User/Author. Equals to `firstName` if `lastName` is not provided and equals to `firstName[space]lastName` if both fields are provided. This is also localized for Authors.
* you can now `GET`, `PUT` and `DELETE` Article either by ID or by slug (of any localization). Covered with tests.
* creating `Article` TOGETHER with localizations in ONE API call (an update for POST `/api/articles` method).
* if no Diaries exist http error **204** is returned
* new response format for getOneDiary: `{ data, prev, next }`, where `prev` and `next` contain `month` and `day` fields indicating the closest diaries to switch to. `data` either contains a requested Diary or is empty.
* awesome Create and Update methods for articles! You can create/update with only call with localization nested in the request.
* a shit-ton of tests. But we might need more!