### PR TITLE
brand and collection trigger 400; videoUrl parsing

### DIFF
--- a/src/api/article/author/tests.js
+++ b/src/api/article/author/tests.js
@@ -77,6 +77,7 @@ describe('Authors API', () => {
             imagePreviewUrl: 'image-url',
             type: 'video',
             authorEmail: 'generated-author-11@wir.by',
+            videoUrl: 'https://www.youtube.com/watch?v=1234567890x',
           })
           .set('Cookie', sessionCookie)
           .expect(200)
@@ -85,6 +86,8 @@ describe('Authors API', () => {
             expect(res.body.brand.slug).equal('wir');
             expect(res.body.author.email).equal('generated-author-11@wir.by');
             expect(res.body.author.firstName).equal('Name 11');
+            expect(res.body.video.platform).equal('youtube');
+            expect(res.body.video.videoId).equal('1234567890x');
           }));
     });
   });

--- a/src/api/article/controller.js
+++ b/src/api/article/controller.js
@@ -84,8 +84,7 @@ const handleArticleLocalizationError = locale => err => {
 export const create = async ({ body, user }, res, next) => {
   try {
     const articleBrand = await ArticleBrand.findOne({
-      // TODO(uladbohdan): to deprecate body.brand.
-      slug: body.brand || body.brandSlug,
+      slug: body.brandSlug,
     }).exec();
     checkIsFound(articleBrand, 400); // Brand is required.
     const brandId = articleBrand._id;
@@ -139,8 +138,7 @@ export const update = async ({ params: { slugOrId }, body, user }, res, next) =>
   try {
     const articleId = await retrieveArticleId(slugOrId).catch(next);
     const [newBrand, newCollection, newAuthor] = await Promise.all([
-      // TODO(uladbohdan): to deprecate body.brand.
-      ArticleBrand.findOne({ slug: body.brand || body.brandSlug }).exec(),
+      ArticleBrand.findOne({ slug: body.brandSlug }).exec(),
       ArticleCollection.findOne({ slug: body.collectionSlug }).exec(),
       User.findOne({ email: body.authorEmail, role: 'author' }).exec(),
     ]);
@@ -148,7 +146,6 @@ export const update = async ({ params: { slugOrId }, body, user }, res, next) =>
     const updFields = omit(body, [
       'author',
       'authorEmail',
-      'brand',
       'brandSlug',
       'collectionSlug',
       'locales',

--- a/src/api/article/controller.tests.js
+++ b/src/api/article/controller.tests.js
@@ -381,6 +381,29 @@ describe('Articles Bundled API', () => {
       })
       .expect(400));
 
+  it('should fail to create an article due to forbidden field', () =>
+    request
+      .post('/api/articles')
+      .set('Cookie', sessionCookie)
+      .send({
+        brandSlug,
+        brand: 'xxx',
+        type: 'text',
+        imagePreviewUrl: 'some-image-url',
+        locales: {
+          be: {
+            title: 'be-title',
+            subtitle: 'be-subtitle',
+            content: 'some-be-text',
+            slug: 'be-slug',
+          },
+        },
+      })
+      .expect(400)
+      .expect(res => {
+        expect(res.body.error.brand).to.contain('forbidden');
+      }));
+
   it('should create an article with localizations with one API call', () =>
     request
       .post('/api/articles')
@@ -550,6 +573,16 @@ describe('Articles Bundled API', () => {
       .set('Cookie', sessionCookie)
       .send({ brandSlug: '' })
       .expect(400));
+
+  it('should fail to remove article collection due to forbidden collection field', () =>
+    request
+      .put('/api/articles/new-en-slug')
+      .set('Cookie', sessionCookie)
+      .send({ collection: 'ololo', collectionSlug: '' })
+      .expect(400)
+      .expect(res => {
+        expect(res.body.error.collection).to.include('forbidden');
+      }));
 
   it('should fail to remove article imagePreviewUrl', () =>
     request

--- a/src/api/article/controller.tests.js
+++ b/src/api/article/controller.tests.js
@@ -291,6 +291,11 @@ describe('Articles Bundled API', () => {
   const brandSlug = 'wir';
   const authorEmail = 'the-best-author-ever@wir.by';
 
+  const validYoutubeID = 'ABCABCABCAB';
+  const validYoutubeLink = `https://www.youtube.com/watch?v=${validYoutubeID}`;
+  const badYoutubeLink = 'https://www.youtube.com/watch?v=BAD-ID';
+  const validVimeoLink = 'https://vimeo.com/197700533';
+
   before(async () => {
     await new ArticleBrand({ slug: brandSlug }).save();
 
@@ -412,7 +417,7 @@ describe('Articles Bundled API', () => {
         brandSlug,
         type: 'text',
         imagePreviewUrl: 'abc',
-        videoUrl: 'https://www.youtube.com/watch?v=1234567890x',
+        videoUrl: validYoutubeLink,
       })
       .expect(400)
       .expect(res => {
@@ -429,7 +434,7 @@ describe('Articles Bundled API', () => {
     request
       .post('/api/articles')
       .set('Cookie', sessionCookie)
-      .send({ ...articleBase, videoUrl: 'https://vimeo.com/197700533' })
+      .send({ ...articleBase, videoUrl: validVimeoLink })
       .expect(400)
       .expect(res => {
         expect(res.body.error).to.contain('badVideoUrl');
@@ -439,7 +444,7 @@ describe('Articles Bundled API', () => {
     request
       .post('/api/articles')
       .set('Cookie', sessionCookie)
-      .send({ ...articleBase, videoUrl: 'https://www.youtube.com/watch?v=BAD-ID' })
+      .send({ ...articleBase, videoUrl: badYoutubeLink })
       .expect(400)
       .expect(res => {
         expect(res.body.error).to.contain('badVideoUrl');
@@ -456,7 +461,7 @@ describe('Articles Bundled API', () => {
         imagePreviewUrl: 'some-image-url',
         authorEmail,
         publishAt: Date.now(),
-        videoUrl: 'https://www.youtube.com/watch?v=1234567890x',
+        videoUrl: validYoutubeLink,
         locales: {
           be: {
             title: 'be-title',
@@ -473,8 +478,8 @@ describe('Articles Bundled API', () => {
         expect(Object.keys(res.body.locales)).has.length(1);
         expect(res.body.locales.be.slug).to.equal('be-slug');
         expect(res.body.video.platform).to.equal('youtube');
-        expect(res.body.video.videoId).to.equal('1234567890x');
-        expect(res.body.video.videoUrl).to.equal('https://www.youtube.com/watch?v=1234567890x');
+        expect(res.body.video.videoId).to.equal(validYoutubeID);
+        expect(res.body.video.videoUrl).to.equal(validYoutubeLink);
       }));
 
   it('should return an article again by ID', () =>
@@ -493,13 +498,13 @@ describe('Articles Bundled API', () => {
       .put('/api/articles/be-slug')
       .set('Cookie', sessionCookie)
       .send({
-        videoUrl: 'https://www.youtube.com/watch?v=ABCABCABCAB',
+        videoUrl: validYoutubeLink,
       })
       .expect(200)
       .expect(res => {
         expect(res.body.video.platform).to.equal('youtube');
-        expect(res.body.video.videoId).to.equal('ABCABCABCAB');
-        expect(res.body.video.videoUrl).to.equal('https://www.youtube.com/watch?v=ABCABCABCAB');
+        expect(res.body.video.videoId).to.equal(validYoutubeID);
+        expect(res.body.video.videoUrl).to.equal(validYoutubeLink);
       }));
 
   it('should change article type to text', () =>

--- a/src/db/data/articles.json
+++ b/src/db/data/articles.json
@@ -106,6 +106,7 @@
         "slug": "slug4-en"
       }
     },
+    "videoId": "OUGvR8UVlSU",
     "imagePreviewUrl": "/test/images/gradient-5.jpg",
     "imageFolderUrl": "/test/images/gradient-1.jpg"
   },

--- a/src/db/scripts/initAll.js
+++ b/src/db/scripts/initAll.js
@@ -90,13 +90,20 @@ const initArticles = (articleBrandsDict, authorsDict) =>
   Promise.all(
     articlesData.map(async rawArticleData => {
       const articleLocales = rawArticleData.locales;
-      const articleData = omit(rawArticleData, ['locales']);
+      const articleData = omit(rawArticleData, ['locales', 'videoId']);
       articleData.brand = articleBrandsDict[articleData.brand];
       if (articleData.authorEmail) {
         articleData.author = authorsDict[articleData.authorEmail];
       }
       if (articleData.publishAt) {
         articleData.publishAt = new Date(articleData.publishAt);
+      }
+      if (articleData.type === 'video') {
+        articleData.video = {
+          platform: 'youtube',
+          videoId: rawArticleData.videoId,
+          videoUrl: `https://www.youtube.com/watch?v=${rawArticleData.videoId}`,
+        };
       }
       const article = new Article(articleData);
       Promise.all(

--- a/src/utils/networks.js
+++ b/src/utils/networks.js
@@ -1,0 +1,19 @@
+import { ValidationError } from './validation';
+
+// Keys of the object are all supported video plarforms.
+// Values are functions checking if ID of the video is (potentially) valid.
+export const VIDEO_PLATFORMS = {
+  youtube: id => /^[a-zA-Z0-9_-]{11}$/.test(id),
+};
+
+export const VIDEO_PLATFORMS_LIST = Object.keys(VIDEO_PLATFORMS);
+
+const YOUTUBE_VIDEO_URL = /youtube\.com\/watch\?v=([a-zA-Z0-9_-]{11})/;
+
+export const parseVideoUrl = videoUrl => {
+  const youtubeMatch = YOUTUBE_VIDEO_URL.exec(videoUrl);
+  if (youtubeMatch) {
+    return { platform: 'youtube', videoId: youtubeMatch[1], videoUrl };
+  }
+  throw new ValidationError('errors.badVideoUrl');
+};

--- a/src/utils/networks.tests.js
+++ b/src/utils/networks.tests.js
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+
+import { parseVideoUrl } from './networks';
+
+describe('Video URL Tests', () => {
+  it('should not accept non-youtube video url', () =>
+    expect(() => parseVideoUrl('https://vimeo.com/197700533')).to.throw());
+
+  it('should not accept youtube video url with broken videoId', () =>
+    expect(() => parseVideoUrl('https://www.youtube.com/watch?v=LOOOL')).to.throw());
+
+  it('should accept youtube video url', () =>
+    expect(parseVideoUrl('https://www.youtube.com/watch?v=OUGvR8UVlSU').videoId).to.be.equal(
+      'OUGvR8UVlSU'
+    ));
+});

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -11,7 +11,7 @@ export const validatePassword = password => {
   }
 };
 
-const createArticleValidator = ({ body }, res, next) => {
+const checkForbiddenFields = body => {
   const errors = {};
 
   ['brand', 'collection'].forEach(field => {
@@ -19,6 +19,12 @@ const createArticleValidator = ({ body }, res, next) => {
       errors[field] = 'frontend is forbidden to send this field to backend';
     }
   });
+
+  return errors;
+};
+
+const createArticleValidator = ({ body }, res, next) => {
+  const errors = checkForbiddenFields(body);
 
   if (body.locales) {
     Object.entries(body.locales).forEach(([locale, localeData]) => {
@@ -41,13 +47,7 @@ const createArticleValidator = ({ body }, res, next) => {
 };
 
 const updateArticleValidator = ({ body }, res, next) => {
-  const errors = {};
-
-  ['brand', 'collection'].forEach(field => {
-    if (Object.prototype.hasOwnProperty.call(body, field)) {
-      errors[field] = 'frontend is forbidden to send this field to backend';
-    }
-  });
+  const errors = checkForbiddenFields(body);
 
   ['brandSlug', 'type', 'imagePreviewUrl'].forEach(field => {
     if (body[field] === '') {

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -13,6 +13,13 @@ export const validatePassword = password => {
 
 const createArticleValidator = ({ body }, res, next) => {
   const errors = {};
+
+  ['brand', 'collection'].forEach(field => {
+    if (Object.prototype.hasOwnProperty.call(body, field)) {
+      errors[field] = 'frontend is forbidden to send this field to backend';
+    }
+  });
+
   if (body.locales) {
     Object.entries(body.locales).forEach(([locale, localeData]) => {
       ['title', 'subtitle', 'slug', 'content'].forEach(field => {
@@ -32,9 +39,15 @@ const createArticleValidator = ({ body }, res, next) => {
 const updateArticleValidator = ({ body }, res, next) => {
   const errors = {};
 
+  ['brand', 'collection'].forEach(field => {
+    if (Object.prototype.hasOwnProperty.call(body, field)) {
+      errors[field] = 'frontend is forbidden to send this field to backend';
+    }
+  });
+
   ['brandSlug', 'type', 'imagePreviewUrl'].forEach(field => {
     if (body[field] === '') {
-      errors[field] = 'errors.fieldUnremovable.';
+      errors[field] = 'errors.fieldUnremovable';
     }
   });
 

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -33,6 +33,10 @@ const createArticleValidator = ({ body }, res, next) => {
     });
   }
 
+  if (body.type === 'text' && body.videoUrl) {
+    errors.video = 'errors.forbiddenForTypeText';
+  }
+
   return next(!isEmpty(errors) && new ValidationError(errors));
 };
 


### PR DESCRIPTION
* Backend will now return `400 Bad Request` on requests containing `brand` or `collection` fields.
* `videoUrl` parsing