### PR TITLE
Omit build step with esm modules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,9 @@ module.exports = {
   },
   settings: {
     'import/resolver': {
-      'babel-module': {},
+      node: {
+        moduleDirectory: ['node_modules', './src'],
+      },
     },
   },
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
   - mongodb
 script:
   - npm run lint
-  - npm run build
   - npm test
 after_success:
   - npm run travis-deploy-once "npm run semantic-release"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![Build Status](https://travis-ci.org/babajka/babajka-backend.svg?branch=master)](https://travis-ci.org/babajka/babajka-backend)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/27a0eb2d7da645b983b464238ca7248e)](https://www.codacy.com/app/babajka/babajka-backend?utm_source=github.com&utm_medium=referral&utm_content=babajka/babajka-backend&utm_campaign=Badge_Grade)
 [![Coverage Status](https://coveralls.io/repos/github/babajka/babajka-backend/badge.svg?branch=master)](https://coveralls.io/github/babajka/babajka-backend?branch=master)
 [![StackShare](https://img.shields.io/badge/tech-stack-0690fa.svg?style=flat)](https://stackshare.io/wir-by/wir-by-backend)
@@ -14,9 +15,7 @@ We use [`airbnb/base`](https://github.com/airbnb/javascript) style guide
 
 - `npm start` runs dev server with watcher and reloading
 
-- `npm run start-prod` runs prod server locally. The same with `npm start` with the difference of building and running on the same machine
-
-- `npm run build` builds prod server into `build/` without running it
+- `npm run start-prod` runs prod server locally
 
 - `npm run init-db` to create database and insert initial test data
 

--- a/esm.js
+++ b/esm.js
@@ -1,0 +1,5 @@
+const loader = require('esm')(module, { cjs: true });
+
+loader('module-alias/register');
+
+module.exports = loader('./index.js');

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import { createServer } from 'http';
 import path from 'path';
+
 import config from 'config';
 import app, { publicPath } from 'server';
 import connectDb from 'db';

--- a/package-lock.json
+++ b/package-lock.json
@@ -4568,6 +4568,11 @@
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
       "dev": true
     },
+    "esm": {
+      "version": "3.0.84",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.84.tgz",
+      "integrity": "sha512-SzSGoZc17S7P+12R9cg21Bdb7eybX25RnIeRZ80xZs+VZ3kdQKzqTp2k4hZJjR7p9l0186TTXSgrxzlMDBktlw=="
+    },
     "espree": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
@@ -8212,6 +8217,11 @@
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
+    },
+    "module-alias": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.1.0.tgz",
+      "integrity": "sha1-w21P0V9/nXES9i+gFThee2WihsE="
     },
     "mongodb": {
       "version": "2.2.33",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,8 @@
     "node": ">=10"
   },
   "scripts": {
-    "start": "nodemon -w index.js -w . --exec babel-node index.js",
-    "start-prod": "npm run build && node build/index.js",
-    "build": "npm run clean && babel . -d build --copy-files --ignore node_modules,postman,build,*tests.js,*testing.js,db/scripts",
-    "clean": "rm -rf build",
+    "start": "nodemon -w index.js -w . --exec node -r esm esm.js",
+    "start-prod": "node -r esm esm.js",
     "init-db": "babel-node src/db/scripts/initAll.js",
     "init-prod-diaries": "babel-node src/db/scripts/initProdDiaries.js",
     "grant-permissions": "babel-node src/db/scripts/grantPermissions.js",
@@ -17,7 +15,7 @@
     "lint": "npm run prettify && eslint index.js src/ --fix",
     "prettier": "prettier --config .prettierrc --write",
     "prettify": "npm run prettier 'src/**/*.{js,md}' '*.js' '*.md'",
-    "mocha": "find ./src -name '*tests.js' | cross-env NODE_ENV=testing xargs mocha --exit --require @babel/register",
+    "mocha": "find ./src -name '*tests.js' | cross-env NODE_ENV=testing xargs mocha --exit -r @babel/register",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "test": "cross-env NODE_ENV=testing nyc npm run mocha && npm run coverage",
     "semantic-release": "semantic-release",
@@ -28,10 +26,12 @@
     "body-parser": "^1.17.2",
     "connect-mongo": "^1.3.2",
     "cors": "^2.8.3",
+    "esm": "^3.0.84",
     "express": "^4.15.3",
     "express-session": "^1.15.4",
     "google-spreadsheet": "^2.0.6",
     "lodash": "^4.17.10",
+    "module-alias": "^2.1.0",
     "mongoose": "^4.13.8",
     "morgan": "^1.8.2",
     "node-http-error": "^2.0.0",
@@ -51,6 +51,9 @@
   "homepage": "https://github.com/babajka/babajka-backend#readme",
   "main": "index.js",
   "moduleRoots": [
+    "./src"
+  ],
+  "_moduleDirectories": [
     "./src"
   ],
   "devDependencies": {


### PR DESCRIPTION
- use [`esm`](https://github.com/standard-things/esm) for `es6` modules (`import / export`)
- with [`module-alias`](https://github.com/ilearnio/module-alias) setup project root to `./src`
- still use [`@babel/node`](https://babeljs.io/docs/en/babel-node) for tests & scripts, did not find a workaround for now

@UladBohdan this is kinda experimental and should be tested on servers