### PR TITLE
Storage API [ IN PROGRESS ]

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -18,6 +18,7 @@ module.exports = {
         'specials',
         'config',
         'db',
+        'storage',
       ],
     ],
     'scope-empty': [2, 'never'],

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "lint": "npm run prettify && eslint index.js src/ --fix",
     "prettier": "prettier --config .prettierrc --write",
     "prettify": "npm run prettier 'src/**/*.{js,md}' '*.js' '*.md'",
-    "mocha": "find ./src -name '*tests.js' | cross-env NODE_ENV=testing xargs mocha --exit -r @babel/register",
+    "mocha": "npm run test:subset",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "test": "cross-env NODE_ENV=testing nyc npm run mocha && npm run coverage",
+    "test:subset": "f(){ find ./src$1 -name '*tests.js' | cross-env NODE_ENV=testing xargs mocha --exit -r @babel/register ;};f",
     "semantic-release": "semantic-release",
     "travis-deploy-once": "travis-deploy-once"
   },

--- a/src/api/helpers/metadata/model.js
+++ b/src/api/helpers/metadata/model.js
@@ -26,17 +26,17 @@ const ObjectMetadataSchema = new Schema({
 
 export const ObjectMetadata = mongoose.model('ObjectMetadata', ObjectMetadataSchema);
 
-export const getInitObjectMetadata = user => ({
+export const getInitObjectMetadata = userId => ({
   createdAt: Date.now(),
-  createdBy: user._id,
+  createdBy: userId,
   updatedAt: Date.now(),
-  updatedBy: user._id,
+  updatedBy: userId,
 });
 
-export const updateObjectMetadata = (oldMetadata, user) => ({
+export const updateObjectMetadata = (oldMetadata, userId) => ({
   ...oldMetadata,
   updatedAt: Date.now(),
-  updatedBy: user._id,
+  updatedBy: userId,
 });
 
 export const mergeWithUpdateMetadata = (data, userId) => ({

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -3,11 +3,13 @@ import { Router } from 'express';
 import userRoutes from 'api/user';
 import articleRoutes from 'api/article';
 import specialsRoutes from 'api/specials';
+import storageRoutes from 'api/storage';
 
 const router = Router();
 
 router.use('/users', userRoutes);
 router.use('/articles', articleRoutes);
 router.use('/specials', specialsRoutes);
+router.use('/storage', storageRoutes);
 
 export default router;

--- a/src/api/storage/controller.js
+++ b/src/api/storage/controller.js
@@ -1,0 +1,51 @@
+import isEmpty from 'lodash/isEmpty';
+
+import { sendJson } from 'utils/api';
+
+import { checkIsFound } from 'utils/validation';
+import { getInitObjectMetadata, mergeWithUpdateMetadata } from 'api/helpers/metadata';
+
+import { StorageEntity } from './model';
+
+const getStorageEntity = (key, accessPolicy) =>
+  StorageEntity.findOne({ key, accessPolicy })
+    .then(checkIsFound)
+    .then(obj => obj.document);
+
+export const getPublicDocument = ({ params: { key } }, res, next) =>
+  getStorageEntity(key, 'public')
+    .then(sendJson(res))
+    .catch(next);
+
+export const getProtectedDocument = ({ params: { key } }, res, next) =>
+  getStorageEntity(key, 'protected')
+    .then(sendJson(res))
+    .catch(next);
+
+export const updateDocument = ({ params: { accessPolicy, key }, body, user }, res, next) => {
+  const fieldsToUpdate = { accessPolicy };
+  if (!isEmpty(body)) {
+    fieldsToUpdate.document = body;
+  }
+
+  return StorageEntity.findOneAndUpdate(
+    { key },
+    mergeWithUpdateMetadata(fieldsToUpdate, user._id),
+    {
+      new: true,
+    }
+  )
+    .then(
+      entity =>
+        entity ||
+        StorageEntity({
+          accessPolicy,
+          key,
+          document: body,
+          metadata: getInitObjectMetadata(user),
+        }).save()
+    )
+    .then(entity => entity.document)
+    .then(sendJson(res))
+    .catch(next);
+};

--- a/src/api/storage/index.js
+++ b/src/api/storage/index.js
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+
+import { requireAuth, verifyPermission } from 'auth';
+
+import * as controller from './controller';
+
+const router = Router();
+
+router.get('/public/:key', controller.getPublicDocument);
+
+router.get(
+  '/protected/:key',
+  requireAuth,
+  verifyPermission('canOperateOnStorage'),
+  controller.getProtectedDocument
+);
+
+router.post(
+  '/:accessPolicy/:key',
+  requireAuth,
+  verifyPermission('canOperateOnStorage'),
+  controller.updateDocument
+);
+
+export default router;

--- a/src/api/storage/model.js
+++ b/src/api/storage/model.js
@@ -1,0 +1,28 @@
+import mongoose from 'mongoose';
+
+import { ObjectMetadata } from 'api/helpers/metadata';
+
+const { Schema } = mongoose;
+
+const StorageEntitySchema = new Schema({
+  key: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  document: {
+    type: Schema.Types.Mixed,
+    required: true,
+  },
+  accessPolicy: {
+    type: String,
+    enum: ['public', 'protected'],
+    required: true,
+  },
+  metadata: {
+    type: ObjectMetadata.schema,
+    required: true,
+  },
+});
+
+export const StorageEntity = mongoose.model('StorageEntity', StorageEntitySchema);

--- a/src/api/storage/tests.js
+++ b/src/api/storage/tests.js
@@ -1,0 +1,105 @@
+import { supertest, expect, dropData, loginTestAdmin } from 'utils/testing';
+
+import app from 'server';
+import 'db/connect';
+
+const request = supertest.agent(app.listen());
+
+describe('Storage API', () => {
+  let sessionCookie;
+
+  before(async () => {
+    sessionCookie = await loginTestAdmin();
+  });
+
+  after(dropData);
+
+  it('should create a new storage entity with public access', () =>
+    request
+      .post('/api/storage/public/public-entity')
+      .set('Cookie', sessionCookie)
+      .send({
+        a: 'b',
+        c: ['d', 'e'],
+      })
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).not.empty();
+        expect(body.a).to.equal('b');
+        expect(body.c).has.length(2);
+      }));
+
+  it('should fail to auth when retrieving public entity as protected with no auth', () =>
+    request.get('/api/storage/protected/public-entity').expect(403));
+
+  it('should fail to retrieve public entity as protected with auth', () =>
+    request
+      .get('/api/storage/protected/public-entity')
+      .set('Cookie', sessionCookie)
+      .expect(404));
+
+  it('should retrieve a public storage entity', () =>
+    request
+      .get('/api/storage/public/public-entity')
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.a).to.equal('b');
+      }));
+
+  it('should create a new storage entity with protected access', () =>
+    request
+      .post('/api/storage/protected/protected-entity')
+      .set('Cookie', sessionCookie)
+      .send({
+        x: 'y',
+      })
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).not.empty();
+        expect(body.x).to.equal('y');
+      }));
+
+  it('should fail to retrieve protected entity without auth', () =>
+    request.get('/api/storage/protected/protected-entity').expect(403));
+
+  it('should retrieve a protected storage entity', () =>
+    request
+      .get('/api/storage/protected/protected-entity')
+      .set('Cookie', sessionCookie)
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).not.empty();
+        expect(body.x).to.equal('y');
+      }));
+
+  it('should make a protected entity public', () =>
+    request
+      .post('/api/storage/public/protected-entity')
+      .set('Cookie', sessionCookie)
+      .expect(200));
+
+  it('should retrieve an updated public storage entity', () =>
+    request
+      .get('/api/storage/public/protected-entity')
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).not.empty();
+        expect(body.x).to.equal('y');
+      }));
+
+  it('should update a document', () =>
+    request
+      .post('/api/storage/public/protected-entity')
+      .set('Cookie', sessionCookie)
+      .send({ x: 'z' })
+      .expect(200));
+
+  it('should retrieve a storage entity with updated document', () =>
+    request
+      .get('/api/storage/public/protected-entity')
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).not.empty();
+        expect(body.x).to.equal('z');
+      }));
+});

--- a/src/auth/tests.js
+++ b/src/auth/tests.js
@@ -1,4 +1,5 @@
 import { supertest, expect, dropData, addUser, testData } from 'utils/testing';
+import * as permissions from 'constants/permissions';
 
 import app from 'server';
 import 'db/connect';
@@ -40,7 +41,9 @@ describe('Auth API', () => {
         expect(res.body.email).to.equal('admin@babajka.io');
         expect(res.headers['set-cookie']).not.empty();
         sessionCookie = res.headers['set-cookie'];
-        expect(Object.keys(res.body.permissions)).to.have.length(3);
+        expect(Object.keys(res.body.permissions)).to.have.length(
+          Object.keys(permissions.admin).length
+        );
       }));
 
   it('should access protected resource', () =>

--- a/src/constants/permissions.js
+++ b/src/constants/permissions.js
@@ -6,8 +6,10 @@
 //    he/she can edit and remove existing articles bun CAN NOT create new.
 // * canManageUsers - the one with this permission can create, edit and remove
 //    and view the full list of users existing.
+// * canModifyStorage - the one with this permission gets full access to Storage API
+//    and can operate on protected Storage Entities.
 
 export const user = {};
 export const author = { ...user, canCreateArticle: true };
 export const contentManager = { ...author, canManageArticles: true };
-export const admin = { ...contentManager, canManageUsers: true };
+export const admin = { ...contentManager, canManageUsers: true, canOperateOnStorage: true };


### PR DESCRIPTION
Storage API to store protected and public documents in the database.

### Extra feature: subset testing!
Usage:
`npm run test:subset -- /auth` - to only run `auth` tests
`npm run test:subset -- /api/storage` - to only run `storage` tests