### PR TITLE
Analytics integration; Storage byKey

### DIFF
--- a/postman/Babajka Backend.postman_collection.json
+++ b/postman/Babajka Backend.postman_collection.json
@@ -550,6 +550,23 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Articles: get all Analytics",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{DOMAIN}}{{API_URL}}/analytics",
+							"host": [
+								"{{DOMAIN}}{{API_URL}}"
+							],
+							"path": [
+								"analytics"
+							]
+						}
+					},
+					"response": []
 				}
 			],
 			"protocolProfileBehavior": {}
@@ -813,6 +830,25 @@
 								"storage",
 								"fibery",
 								"sidebar"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Features enabled",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{DOMAIN}}{{API_URL}}/storage/byKey/features",
+							"host": [
+								"{{DOMAIN}}{{API_URL}}"
+							],
+							"path": [
+								"storage",
+								"byKey",
+								"features"
 							]
 						}
 					},

--- a/src/api/article/analytics/controller.js
+++ b/src/api/article/analytics/controller.js
@@ -1,0 +1,9 @@
+import { sendJson } from 'utils/api';
+
+import ContentAnalytics from './model';
+
+export const getAll = (_, res, next) =>
+  ContentAnalytics.find({})
+    .select('-_id')
+    .then(sendJson(res))
+    .catch(next);

--- a/src/api/article/analytics/controller.js
+++ b/src/api/article/analytics/controller.js
@@ -4,6 +4,6 @@ import ContentAnalytics from './model';
 
 export const getAll = (_, res, next) =>
   ContentAnalytics.find({})
-    .select('-_id')
+    .select('-_id -__v')
     .then(sendJson(res))
     .catch(next);

--- a/src/api/article/analytics/controller.tests.js
+++ b/src/api/article/analytics/controller.tests.js
@@ -1,0 +1,39 @@
+import HttpStatus from 'http-status-codes';
+
+import { supertest, expect, dropData, loginTestAdmin } from 'utils/testing';
+
+import app from 'server';
+import 'db/connect';
+
+import ContentAnalytics from './model';
+
+const request = supertest.agent(app.listen());
+
+describe('Analytics API', () => {
+  let sessionCookie;
+
+  const sampleAnalyticsData = [
+    { slug: 'slug1', metrics: { be: 120 } },
+    { slug: 'slug2', metrics: { be: 100, ru: 10 } },
+  ];
+
+  before(async () => {
+    await dropData();
+
+    sessionCookie = await loginTestAdmin();
+
+    await Promise.all(sampleAnalyticsData.map(data => ContentAnalytics(data).save()));
+  });
+
+  it('should fail to get analytics with no auth', () =>
+    request.get('/api/analytics').expect(HttpStatus.FORBIDDEN));
+
+  it('should get all analytics', () =>
+    request
+      .get('/api/analytics')
+      .set('Cookie', sessionCookie)
+      .expect(HttpStatus.OK)
+      .expect(({ body }) => {
+        expect(body).to.deep.equal(sampleAnalyticsData);
+      }));
+});

--- a/src/api/article/analytics/index.js
+++ b/src/api/article/analytics/index.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+
+import { requireAuth, verifyPermission } from 'auth';
+
+import * as controller from './controller';
+
+const router = Router();
+
+router.get('/', requireAuth, verifyPermission('canManageArticles'), controller.getAll);
+
+export default router;

--- a/src/api/article/analytics/model.js
+++ b/src/api/article/analytics/model.js
@@ -2,11 +2,18 @@ import mongoose from 'mongoose';
 
 import Joi, { joiToMongoose } from 'utils/joi';
 
+import { LOCALES } from 'constants/misc';
+
 export const joiContentAnalyticsSchema = Joi.object({
   slug: Joi.string()
     .meta({ unique: true })
     .required(),
-  metrics: Joi.object(),
+  metrics: Joi.object(
+    LOCALES.reduce((acc, loc) => {
+      acc[loc] = Joi.number();
+      return acc;
+    }, {})
+  ),
 });
 
 const ContentAnalyticsSchema = joiToMongoose(joiContentAnalyticsSchema);

--- a/src/api/article/analytics/model.js
+++ b/src/api/article/analytics/model.js
@@ -3,7 +3,9 @@ import mongoose from 'mongoose';
 import Joi, { joiToMongoose } from 'utils/joi';
 
 export const joiContentAnalyticsSchema = Joi.object({
-  slug: Joi.string(),
+  slug: Joi.string()
+    .meta({ unique: true })
+    .required(),
   metrics: Joi.object(),
 });
 

--- a/src/api/article/analytics/model.js
+++ b/src/api/article/analytics/model.js
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose';
+
+import Joi, { joiToMongoose } from 'utils/joi';
+
+export const joiContentAnalyticsSchema = Joi.object({
+  slug: Joi.string(),
+  metrics: Joi.object(),
+});
+
+const ContentAnalyticsSchema = joiToMongoose(joiContentAnalyticsSchema);
+
+const ContentAnalytics = mongoose.model('contentAnalytics', ContentAnalyticsSchema);
+
+export default ContentAnalytics;

--- a/src/api/article/article.model.js
+++ b/src/api/article/article.model.js
@@ -70,24 +70,19 @@ const joiArticleSchema = Joi.object({
 // FIXME: falls with { audio: null, video: null }
 // .nand('video', 'audio');
 
-const IMAGES_BY_TYPE = {
-  text: ['page', 'horizontal', 'vertical'],
-  video: ['horizontal', 'vertical'],
-  audio: ['horizontal', 'vertical'],
-};
+const COVER_FORMATS = ['page', 'horizontal', 'vertical'];
 
-const getImagesSchema = type =>
+const getImagesSchema = () =>
   Joi.object(
-    IMAGES_BY_TYPE[type].reduce((acc, cur) => {
+    COVER_FORMATS.reduce((acc, cur) => {
       acc[cur] = Joi.image();
       return acc;
     }, {})
   );
 
 export const validateArticle = data => {
-  const { type } = data;
   const schema = joiArticleSchema.keys({
-    images: getImagesSchema(type).required(),
+    images: getImagesSchema().required(),
     // TODO: conditional require `video` or `audio`
   });
   return defaultValidator(data, schema);

--- a/src/api/article/article.model.js
+++ b/src/api/article/article.model.js
@@ -197,18 +197,16 @@ const populateWithAnalytics = user => async articles => {
     return articles;
   }
 
-  await ContentAnalytics.find()
-    .then(obj => keyBy(obj, 'slug'))
-    .then(analytics => {
-      articles.forEach(({ locales: localizedArticles }, idx) => {
-        Object.values(localizedArticles).forEach(({ locale, slug }) => {
-          const analytic = analytics[slug];
-          if (analytic && analytic.metrics) {
-            set(articles, [idx, 'locales', locale, '_doc', 'metrics'], analytic.metrics);
-          }
-        });
-      });
+  const analytics = keyBy(await ContentAnalytics.find(), 'slug');
+
+  articles.forEach(({ locales: localizedArticles }, idx) => {
+    Object.values(localizedArticles).forEach(({ locale, slug }) => {
+      const analytic = analytics[slug];
+      if (analytic && analytic.metrics) {
+        set(articles, [idx, 'locales', locale, '_doc', 'metrics'], analytic.metrics);
+      }
     });
+  });
 
   return articles;
 };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import userRoutes from 'api/user';
 import articleRoutes from 'api/article';
+import analyticsRoutes from 'api/article/analytics';
 import coreRoutes from 'api/core';
 import mailRoutes from 'api/mail';
 import specialsRoutes from 'api/specials';
@@ -13,6 +14,7 @@ import filesProxy from 'api/files';
 const router = Router();
 
 router.use('/articles', articleRoutes);
+router.use('/analytics', analyticsRoutes);
 router.use('/core', coreRoutes);
 router.use('/mail', mailRoutes);
 router.use('/specials', specialsRoutes);

--- a/src/api/storage/controller.js
+++ b/src/api/storage/controller.js
@@ -121,3 +121,10 @@ export const fiberySidebar = async ({ user }, res, next) => {
     return next(err);
   }
 };
+
+export const getByKey = ({ params: { documentKey } }, res, next) =>
+  StorageEntity.getValue(documentKey)
+    .then(checkIsFound)
+    .then(entity => entity.document)
+    .then(sendJson(res))
+    .catch(next);

--- a/src/api/storage/index.js
+++ b/src/api/storage/index.js
@@ -42,4 +42,6 @@ router.post(
   controller.fiberySidebar
 );
 
+router.get('/byKey/:documentKey', controller.getByKey);
+
 export default router;

--- a/src/services/fibery/index.js
+++ b/src/services/fibery/index.js
@@ -85,7 +85,7 @@ const getArticleData = async url => {
   });
 
   const formatArticle = toWirFormat({
-    mapping: { Podcast: 'audio', publication: 'publishAt' },
+    mapping: { Podcast: 'audio', 'Publication Time': 'publishAt' },
     mapper: (key, lang = '') => (lang ? `locales.${lang}.${key}` : key),
     formatters: {
       authors: TAGS_FORMATTER,

--- a/src/services/fibery/query.js
+++ b/src/services/fibery/query.js
@@ -3,7 +3,7 @@ import { DOC_SECRET_NAME } from './constants';
 
 export const FIBERY_DEFAULT = ['fibery/id', 'fibery/public-id'];
 
-export const ARTICLE_FIELDS = ['Keywords', 'publication-date'];
+export const ARTICLE_FIELDS = ['Keywords', 'Publication Time'];
 
 export const ARTICLE_LOC_FIELDS = ['Title', 'Subtitle', 'Slug'];
 


### PR DESCRIPTION
ANALYTICS
* `/api/analytics` endpoint (auth required) to get all analytics
* responses for articles (e.g. `/api/articles?take=1`) are populated with analytics (check out `[].locales.{locale}.metrics` path). Auth required. `metrics` is a dict: `{ be: A, ru: B }` where locales are languages of interface. `metrics` may be absent if the page was never opened
* Admin Panel interface updated: https://github.com/babajka/babajka-frontend/pull/99

FEATURE SWITCH
* new Storage endpoint `/api/storage/byKey/{key}` to get documents with no extra processing
* https://dev.wir.by/api/storage/byKey/features

ALSO
* `page` images are allowed for all types of articles

TODO:
* to remove 'Publication Date' field from Fibery (once Prod and Dev backends are replaced with this one)